### PR TITLE
refactor: 창 닫힘 방지 로직 useBeforeUnloadBlocker 훅으로 분리 및 (main) layout 패딩 변경

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -7,7 +7,7 @@ export default function MainLayout({ children }: { children: ReactNode }) {
   return (
     <>
       <Header />
-      <main className="flex-grow bg-gray-100 p-10">{children}</main>
+      <main className="flex-grow bg-gray-100 p-5 xs:p-10">{children}</main>
       <Footer />
     </>
   );

--- a/src/app/(main)/write/page.tsx
+++ b/src/app/(main)/write/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 import BackButton from '@/shared/ui/navigation/BackButton';
 
@@ -8,24 +8,12 @@ import {
   PostHashTagSection,
   SubmitButton,
 } from '@/feature/write/ui';
+import { useBeforeUnloadBlocker } from '@/feature/write/hooks';
 
 const WritePage = () => {
   const [tab, setTab] = useState<'file' | 'thumbnail'>('file');
 
-  useEffect(() => {
-    // 창 닫기, 새로고침 시 실행되는 함수
-    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      e.preventDefault(); // 기본 동작 막음 (필수)
-    };
-
-    window.addEventListener('beforeunload', handleBeforeUnload);
-
-    // 컴포넌트 unmount 시 이벤트 제거
-    return () => {
-      window.removeEventListener('beforeunload', handleBeforeUnload);
-    };
-  }, []);
-
+  useBeforeUnloadBlocker();
   return (
     <>
       <div className="flex flex-col gap-5">
@@ -34,7 +22,6 @@ const WritePage = () => {
         <form
           onSubmit={(e) => {
             e.preventDefault();
-            // 여기서 API 호출이나 상태 처리 등 수행
           }}
           className="flex flex-col gap-8"
         >

--- a/src/feature/write/hooks/index.ts
+++ b/src/feature/write/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useBeforeUnloadBlocker';

--- a/src/feature/write/hooks/useBeforeUnloadBlocker.ts
+++ b/src/feature/write/hooks/useBeforeUnloadBlocker.ts
@@ -1,0 +1,16 @@
+// hooks/useBeforeUnloadBlocker.ts
+import { useEffect } from 'react';
+
+const useBeforeUnloadBlocker = () => {
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = ''; // 일부 브라우저에서 경고창 표시 위해 필요
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, []);
+};
+
+export { useBeforeUnloadBlocker };

--- a/src/shared/ui/footer/Footer.tsx
+++ b/src/shared/ui/footer/Footer.tsx
@@ -1,6 +1,6 @@
 const Footer = () => {
   return (
-    <footer className="bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 py-4 mt-auto">
+    <footer className="bg-gray-800 text-gray-300 py-4 mt-auto">
       <div className="container mx-auto text-center text-sm">
         <p>
           &copy; {new Date().getFullYear()} Verdict.gg. All Rights Reserved.


### PR DESCRIPTION
- beforeunload 이벤트 등록 로직을 useBeforeUnloadBlocker 커스텀 훅으로 분리하여 코드 가독성과 책임 분리 개선
- main layout의 좌우 패딩 값을 조정하여 전체 페이지 마진 일관성 개선