### PR TITLE
refactor: 분리된 UI 컴포넌트 및 커스텀 훅 적용하여 NotificationMenu와 ProfileMenu 리팩토링

### DIFF
--- a/src/feature/notification/hooks/index.ts
+++ b/src/feature/notification/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useNotificationMenu';

--- a/src/feature/notification/hooks/useNotificationMenu.ts
+++ b/src/feature/notification/hooks/useNotificationMenu.ts
@@ -1,0 +1,8 @@
+import { useRef, useState } from 'react';
+
+export function useNotificationMenu() {
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  return { open, setOpen, menuRef };
+}

--- a/src/feature/notification/ui/NotificationButton.tsx
+++ b/src/feature/notification/ui/NotificationButton.tsx
@@ -1,0 +1,21 @@
+import { Button } from '@/components/common';
+import { Bell } from 'lucide-react';
+import { Dispatch, SetStateAction } from 'react';
+interface Props {
+  setOpen: Dispatch<SetStateAction<boolean>>;
+}
+export const NotificationButton = ({ setOpen }: Props) => {
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      title="알림"
+      className="relative"
+      onClick={() => setOpen((prev) => !prev)}
+      aria-label="Notification menu"
+    >
+      <Bell className="w-5 h-5 text-gray-600" />
+      {/* <span className="absolute top-1.5 right-1.5 w-2 h-2 bg-red-500 rounded-full" /> 알림 있을 때 표시 */}
+    </Button>
+  );
+};

--- a/src/feature/notification/ui/NotificationDropdown.tsx
+++ b/src/feature/notification/ui/NotificationDropdown.tsx
@@ -1,0 +1,35 @@
+export const NotificationDropdown = () => {
+  const notifications: string[] = []; // 추후 props로 받을 수도 있음
+
+  return (
+    <div className="absolute min-h-[300px] right-0 mt-2 w-60 xs:w-80 rounded-lg border border-primary bg-white shadow-lg z-50 overflow-hidden flex flex-col justify-between">
+      {/* 제목 */}
+      <div className="px-4 py-3 border-b">
+        <p className="text-sm font-semibold text-gray-800">🔔 전체</p>
+      </div>
+
+      {/* 본문 */}
+      <div className="flex flex-col justify-between flex-1">
+        <div className="px-4 py-5 text-sm text-gray-600 flex-1">
+          {notifications.length === 0 ? (
+            <div className="space-y-2 text-center text-gray-500 text-sm">
+              <p>새로운 알람이 없습니다!</p>
+            </div>
+          ) : (
+            notifications.map((msg, i) => (
+              <div key={i} className="py-2 border-b last:border-none">
+                {msg}
+              </div>
+            ))
+          )}
+        </div>
+
+        <div className="px-4 pb-4">
+          <p className="text-xs text-gray-400 text-center">
+            최대 14일 전까지의 알림을 확인할 수 있어요
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/feature/notification/ui/NotificationMenu.tsx
+++ b/src/feature/notification/ui/NotificationMenu.tsx
@@ -1,73 +1,20 @@
 'use client';
-import { useEffect, useRef, useState } from 'react';
-import { Bell } from 'lucide-react';
-import { Button } from '@/components/common';
 
-const NotificationMenu = () => {
-  const [open, setOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement>(null); // 메뉴 영역 전체 참조
+import { useClickOutside } from '@/shared/lib/hooks';
+import { useNotificationMenu } from '../hooks';
+import { NotificationButton } from './NotificationButton';
+import { NotificationDropdown } from './NotificationDropdown';
 
+export const NotificationMenu = () => {
+  const { open, setOpen, menuRef } = useNotificationMenu();
   // 바깥 클릭 시 닫기
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
-
-  const notifications: string[] = []; // 알림 데이터 배열
+  useClickOutside(menuRef, () => setOpen(false));
 
   return (
     <div className="relative" ref={menuRef}>
-      <Button
-        variant="ghost"
-        size="icon"
-        title="알림"
-        className="relative"
-        onClick={() => setOpen((prev) => !prev)}
-        aria-label="Notification menu"
-      >
-        <Bell className="w-5 h-5 text-gray-600" />
-        {/* <span className="absolute top-1.5 right-1.5 w-2 h-2 bg-red-500 rounded-full" /> 알림 있을 때 표시 */}
-      </Button>
+      <NotificationButton setOpen={setOpen} />
 
-      {open && (
-        <div className="absolute min-h-[300px] right-0 mt-2 w-60 xs:w-80 rounded-lg border border-primary bg-white shadow-lg z-50 overflow-hidden flex flex-col justify-between">
-          {/* 제목 */}
-          <div className="px-4 py-3 border-b">
-            <p className="text-sm font-semibold text-gray-800">🔔 전체</p>
-          </div>
-
-          {/* 알림 + 안내 문구를 묶음 */}
-          <div className="flex flex-col justify-between flex-1">
-            <div className="px-4 py-5 text-sm text-gray-600 flex-1">
-              {notifications.length === 0 ? (
-                <div className="space-y-2 text-center text-gray-500 text-sm">
-                  <p>새로운 알람이 없습니다!</p>
-                </div>
-              ) : (
-                notifications.map((msg, i) => (
-                  <div key={i} className="py-2 border-b last:border-none">
-                    {msg}
-                  </div>
-                ))
-              )}
-            </div>
-
-            {/* 항상 하단에 붙도록 */}
-            <div className="px-4 pb-4">
-              <p className="text-xs text-gray-400 text-center">
-                최대 14일 전까지의 알림을 확인할 수 있어요
-              </p>
-            </div>
-          </div>
-        </div>
-      )}
+      {open && <NotificationDropdown />}
     </div>
   );
 };
-
-export default NotificationMenu;

--- a/src/feature/notification/ui/index.ts
+++ b/src/feature/notification/ui/index.ts
@@ -1,0 +1,3 @@
+export * from './NotificationDropdown';
+export * from './NotificationMenu';
+export * from './NotificationButton';

--- a/src/feature/profile/hooks/index.ts
+++ b/src/feature/profile/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useProfileMenu';

--- a/src/feature/profile/hooks/useProfileMenu.ts
+++ b/src/feature/profile/hooks/useProfileMenu.ts
@@ -1,0 +1,15 @@
+import { useRef, useState } from 'react';
+
+export function useProfileMenu() {
+  const [open, setOpen] = useState(false);
+  const [showProfileModal, setShowProfileModal] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  return {
+    open,
+    setOpen,
+    showProfileModal,
+    setShowProfileModal,
+    wrapperRef,
+  };
+}

--- a/src/feature/profile/ui/Modal.tsx
+++ b/src/feature/profile/ui/Modal.tsx
@@ -12,7 +12,7 @@ import {
 import { Pencil } from 'lucide-react';
 import Image from 'next/image';
 
-export default function ProfileModal({
+export function ProfileModal({
   open,
   onClose,
 }: {

--- a/src/feature/profile/ui/ProfileButton.tsx
+++ b/src/feature/profile/ui/ProfileButton.tsx
@@ -1,0 +1,18 @@
+import { User } from 'lucide-react';
+import { Button } from '@/components/common';
+
+interface Props {
+  onClick: () => void;
+}
+
+export const ProfileButton = ({ onClick }: Props) => (
+  <Button
+    variant="ghost"
+    title="프로필"
+    onClick={onClick}
+    aria-label="Profile menu"
+    size="icon"
+  >
+    <User className="w-5 h-5 text-gray-600" />
+  </Button>
+);

--- a/src/feature/profile/ui/ProfileDropdown.tsx
+++ b/src/feature/profile/ui/ProfileDropdown.tsx
@@ -1,0 +1,12 @@
+import { ProfileInfo, ProfileMenuList } from './index';
+
+interface Props {
+  onProfileClick: () => void;
+}
+
+export const ProfileDropdown = ({ onProfileClick }: Props) => (
+  <div className="absolute right-0 mt-2 w-56 rounded-lg border border-primary bg-white shadow-lg z-50">
+    <ProfileInfo />
+    <ProfileMenuList onProfileClick={onProfileClick} />
+  </div>
+);

--- a/src/feature/profile/ui/ProfileInfo.tsx
+++ b/src/feature/profile/ui/ProfileInfo.tsx
@@ -1,0 +1,17 @@
+import Image from 'next/image';
+
+export const ProfileInfo = () => (
+  <div className="flex items-center gap-3 p-4 border-b">
+    <Image
+      src="/path/to/profileImage.png"
+      alt="Profile"
+      width={40}
+      height={40}
+      className="rounded-full"
+    />
+    <div className="text-sm">
+      <p className="font-semibold">ㅇㅇㅇㅇㅇ</p>
+      <p className="text-gray-500 text-xs">smm45108@gmail.com</p>
+    </div>
+  </div>
+);

--- a/src/feature/profile/ui/ProfileMenu.tsx
+++ b/src/feature/profile/ui/ProfileMenu.tsx
@@ -1,90 +1,26 @@
 'use client';
-import { useEffect, useRef, useState } from 'react';
-import { User, LogOut, BookText, Gavel, UserCircle } from 'lucide-react';
-import Image from 'next/image';
-import { Button } from '@/components/common';
-import ProfileModal from '@/feature/profile/ui/Modal';
-import Link from 'next/link';
+
+import { useProfileMenu } from '../hooks/useProfileMenu';
+import { useClickOutside } from '@/shared/lib/hooks';
+import { ProfileButton, ProfileDropdown, ProfileModal } from './index';
 
 const ProfileMenu = () => {
-  const [open, setOpen] = useState(false);
-  const [showProfileModal, setShowProfileModal] = useState(false); // 모달 열림 여부
-  const wrapperRef = useRef<HTMLDivElement>(null); // 버튼+메뉴 전체 감지
+  const { open, setOpen, showProfileModal, setShowProfileModal, wrapperRef } =
+    useProfileMenu();
 
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        wrapperRef.current &&
-        !wrapperRef.current.contains(event.target as Node)
-      ) {
-        setOpen(false);
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, []);
+  useClickOutside(wrapperRef, () => setOpen(false));
 
   return (
     <>
       <div className="relative" ref={wrapperRef}>
-        <Button
-          variant="ghost"
-          title="프로필"
-          onClick={() => setOpen((prev) => !prev)}
-          aria-label="Profile menu"
-          size="icon"
-        >
-          <User className="w-5 h-5 text-gray-600" />
-        </Button>
-
+        <ProfileButton onClick={() => setOpen((prev) => !prev)} />
         {open && (
-          <div className="absolute right-0 mt-2 w-56 rounded-lg border border-primary bg-white shadow-lg z-50">
-            {/* 프로필 정보 */}
-            <div className="flex items-center gap-3 p-4 border-b">
-              <Image
-                src="/path/to/profileImage.png"
-                alt="Profile"
-                width={40}
-                height={40}
-                className="rounded-full"
-              />
-              <div className="text-sm">
-                <p className="font-semibold">ㅇㅇㅇㅇㅇ</p>
-                <p className="text-gray-500 text-xs">smm45108@gmail.com</p>
-              </div>
-            </div>
-
-            {/* 메뉴 리스트 */}
-            <ul className="py-1 text-sm">
-              <li
-                onClick={() => {
-                  setShowProfileModal(true);
-                  setOpen(false);
-                }}
-                className="flex items-center gap-2 px-4 py-2 hover:bg-gray-100 cursor-pointer"
-              >
-                <UserCircle className="w-4 h-4" />
-                프로필
-              </li>
-              <Link href="/mypost">
-                <li className="flex items-center gap-2 px-4 py-2 hover:bg-gray-100 cursor-pointer">
-                  <BookText className="w-4 h-4" />
-                  내가 쓴 글
-                </li>
-              </Link>
-              <li className="flex items-center gap-2 px-4 py-2 hover:bg-gray-100 cursor-pointer">
-                <Gavel className="w-4 h-4" />
-                내가 내린 판결
-              </li>
-              <li className="flex items-center gap-2 px-4 py-2 hover:bg-gray-100 text-red-500 cursor-pointer">
-                <LogOut className="w-4 h-4" />
-                로그아웃
-              </li>
-            </ul>
-          </div>
+          <ProfileDropdown
+            onProfileClick={() => {
+              setShowProfileModal(true);
+              setOpen(false);
+            }}
+          />
         )}
       </div>
       <ProfileModal

--- a/src/feature/profile/ui/ProfileMenuList.tsx
+++ b/src/feature/profile/ui/ProfileMenuList.tsx
@@ -1,0 +1,32 @@
+import { BookText, Gavel, LogOut, UserCircle } from 'lucide-react';
+import Link from 'next/link';
+
+interface Props {
+  onProfileClick: () => void;
+}
+
+export const ProfileMenuList = ({ onProfileClick }: Props) => (
+  <ul className="py-1 text-sm">
+    <li
+      onClick={onProfileClick}
+      className="flex items-center gap-2 px-4 py-2 hover:bg-gray-100 cursor-pointer"
+    >
+      <UserCircle className="w-4 h-4" />
+      프로필
+    </li>
+    <Link href="/myPost">
+      <li className="flex items-center gap-2 px-4 py-2 hover:bg-gray-100 cursor-pointer">
+        <BookText className="w-4 h-4" />
+        내가 쓴 글
+      </li>
+    </Link>
+    <li className="flex items-center gap-2 px-4 py-2 hover:bg-gray-100 cursor-pointer">
+      <Gavel className="w-4 h-4" />
+      내가 내린 판결
+    </li>
+    <li className="flex items-center gap-2 px-4 py-2 hover:bg-gray-100 text-red-500 cursor-pointer">
+      <LogOut className="w-4 h-4" />
+      로그아웃
+    </li>
+  </ul>
+);

--- a/src/feature/profile/ui/index.ts
+++ b/src/feature/profile/ui/index.ts
@@ -1,2 +1,6 @@
 export * from './Modal';
 export * from './ProfileMenu';
+export * from './ProfileButton';
+export * from './ProfileDropdown';
+export * from './ProfileInfo';
+export * from './ProfileMenuList';

--- a/src/shared/lib/hooks/index.ts
+++ b/src/shared/lib/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './useIsMobile';
+export * from './useClickOutside';

--- a/src/shared/lib/hooks/useClickOutside.ts
+++ b/src/shared/lib/hooks/useClickOutside.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+function useClickOutside<T extends HTMLElement>(
+  ref: React.RefObject<T | null>,
+  callback: () => void
+) {
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        callback();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [ref, callback]);
+}
+
+export { useClickOutside };

--- a/src/shared/ui/header/Header.tsx
+++ b/src/shared/ui/header/Header.tsx
@@ -5,7 +5,7 @@ import { usePathname } from 'next/navigation';
 import { Button, Input } from '@/components/common';
 import { Pencil } from 'lucide-react';
 import ProfileMenu from '@/feature/profile/ui/ProfileMenu';
-import NotificationMenu from '@/feature/notification/ui/NotificationMenu';
+import { NotificationMenu } from '@/feature/notification/ui';
 
 const Header = () => {
   const pathname = usePathname();


### PR DESCRIPTION
- NotificationMenu와 ProfileMenu의 버튼 및 드롭다운 UI를 별도 컴포넌트로 분리
- useClickOutside와 커스텀 훅을 활용해 로직을 정리하고 재사용성을 높임
- 전체적으로 가독성과 유지보수성을 개선